### PR TITLE
CoD MW2019 MWII MWIII, Cold War, Vanguard, Black Ops 4, Infinite Warfare, MWR, Black Ops 3, offline & LAN Unlock All & Easter egg, Elixir Talisman enabler & LAN unlock & Split screen unlock patch

### DIFF
--- a/patches/xml/CallOfDutyBlackOpsColdWar-Orbis.xml
+++ b/patches/xml/CallOfDutyBlackOpsColdWar-Orbis.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+		<ID>CUSA24267</ID>
+    </TitleID>
+    <Metadata Title="Call of Duty: Black Ops Cold War"
+              Name="Unlock all in local multiplayer, unlock Custom Classes to 12."
+              Note="Unlock all is ported from PS5 patch made by Alaix(@HeyImAlaix), unlock all blueprints, accessories, stickers, finishing moves, gestures and bundle lockers. Operators are not all unlocked, only 13 in total. May update in future. For version 1.27 DUPLEX release. May add other versions in the future."
+			  Author="zhm86(@JayChou03680255) credit to Alaix(@HeyImAlaix)"
+              PatchVer="1.0"
+              AppVer="01.27"
+              AppElf="eboot.bin">
+		<PatchList>
+			<Line Type="bytes" Address="0x00bc8c12" Value="e9d92a3c0190"/>
+			<Line Type="bytes" Address="0x01f8b6f0" Value="b80a0000004863f04889dfe918d5c3fe"/>
+			<Line Type="bytes" Address="0x017d6f4a" Value="be00000000"/>
+			<Line Type="bytes" Address="0x00bc9666" Value="31f690"/>
+			<Line Type="bytes" Address="0x011a3f7d" Value="e97e77de0090"/>
+			<Line Type="bytes" Address="0x01f8b700" Value="48c7c6010000004889d7e9748821ff"/>
+			<Line Type="bytes" Address="0x00bcccae" Value="31f690"/>
+			<Line Type="bytes" Address="0x00bc95d6" Value="e935213c0190"/>
+			<Line Type="bytes" Address="0x01f8b710" Value="be010000004889dfe9bfdec3fe"/>
+			<Line Type="bytes" Address="0x00bc9195" Value="31f690"/>
+			<Line Type="bytes" Address="0x00b8a183" Value="e9981540019090"/>
+			<Line Type="bytes" Address="0x01f8b720" Value="488d1539dec3fe48be6b46f57a415929244889dfe8b72dc0fe488d1520dec3fe48bee528da0e2feb18684889dfe89e2dc0fe488d1507dec3fe48be05c041aa02dd876e4889dfe8852dc0fe488d15eeddc3fe48beca1d5675bb89d5414889dfe86c2dc0fee913eabffe90909090"/>
+			<Line Type="bytes" Address="0x009c95bb" Value="01"/>
+			<Line Type="bytes" Address="0x009c9625" Value="e9761f5c01"/>
+			<Line Type="bytes" Address="0x009c96cb" Value="e9e01e5c01"/>
+			<Line Type="bytes" Address="0x009c98f9" Value="e9c21c5c019090"/>
+			<Line Type="bytes" Address="0x00baab95" Value="e9360a3e01909090"/>
+			<Line Type="bytes" Address="0x00baad33" Value="e9b8083e0190"/>
+			<Line Type="bytes" Address="0x00bb3a0e" Value="c7"/>
+			<Line Type="bytes" Address="0x00bb3a1e" Value="b7"/>
+			<Line Type="bytes" Address="0x00bb3a32" Value="a3"/>
+			<Line Type="bytes" Address="0x00bb3a44" Value="91"/>
+			<Line Type="bytes" Address="0x00bb3a58" Value="7d"/>
+			<Line Type="bytes" Address="0x00bb3a8e" Value="4a"/>
+			<Line Type="bytes" Address="0x00bb3a96" Value="42"/>
+			<Line Type="bytes" Address="0x00bb3ad8" Value="00"/>
+			<Line Type="bytes" Address="0x00bb3ae2" Value="9090"/>
+			<Line Type="bytes" Address="0x00bb3e1e" Value="c7"/>
+			<Line Type="bytes" Address="0x00bb3e2e" Value="b7"/>
+			<Line Type="bytes" Address="0x00bb3e42" Value="a3"/>
+			<Line Type="bytes" Address="0x00bb3e54" Value="91"/>
+			<Line Type="bytes" Address="0x00bb3e68" Value="7d"/>
+			<Line Type="bytes" Address="0x00bb3e9e" Value="4a"/>
+			<Line Type="bytes" Address="0x00bb3ea6" Value="42"/>
+			<Line Type="bytes" Address="0x00bb3ee8" Value="00"/>
+			<Line Type="bytes" Address="0x00bb3ef2" Value="9090"/>
+			<Line Type="bytes" Address="0x00bb439e" Value="c7"/>
+			<Line Type="bytes" Address="0x00bb43ae" Value="b7"/>
+			<Line Type="bytes" Address="0x00bb43c2" Value="a3"/>
+			<Line Type="bytes" Address="0x00bb43d4" Value="91"/>
+			<Line Type="bytes" Address="0x00bb43e8" Value="7d"/>
+			<Line Type="bytes" Address="0x00bb441e" Value="4a"/>
+			<Line Type="bytes" Address="0x00bb4426" Value="42"/>
+			<Line Type="bytes" Address="0x00bb4468" Value="00"/>
+			<Line Type="bytes" Address="0x00bb4472" Value="9090"/>
+			<Line Type="bytes" Address="0x0119a1b2" Value="e94914df0090"/>
+			<Line Type="bytes" Address="0x011a09f9" Value="e912acde009090"/>
+			<Line Type="bytes" Address="0x011a3cb1" Value="e96a79de00909090"/>
+			<Line Type="bytes" Address="0x011a4c4e" Value="e9dd69de0090"/>
+			<Line Type="bytes" Address="0x011a5500" Value="e93b61de0090"/>
+			<Line Type="bytes" Address="0x011a6691" Value="e9ba4fde009090"/>
+			<Line Type="bytes" Address="0x011a67f8" Value="e9634ede0090"/>
+			<Line Type="bytes" Address="0x011cfcd7" Value="e994b9db00"/>
+			<Line Type="bytes" Address="0x011cfe46" Value="e935b8db00"/>
+			<Line Type="bytes" Address="0x011ec3d1" Value="e9baf2d900"/>
+			<Line Type="bytes" Address="0x0121763e" Value="e95d40d7009090"/>
+			<Line Type="bytes" Address="0x01bc5986" Value="01"/>
+			<Line Type="bytes" Address="0x01bc5995" Value="01"/>
+			<Line Type="bytes" Address="0x01bc59a3" Value="01"/>
+			<Line Type="bytes" Address="0x01bc59b5" Value="01"/>
+			<Line Type="bytes" Address="0x01bc59d8" Value="d45c3c00"/>
+			<Line Type="bytes" Address="0x01bc5a15" Value="975c3c00e9a25c3c00"/>
+			<Line Type="bytes" Address="0x01bc5a44" Value="bb01000000909090"/>
+			<Line Type="bytes" Address="0x01bc5b98" Value="e9335b3c00909090"/>
+			<Line Type="bytes" Address="0x01f8b5a0" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b5a5" Value="4139cbe97de0a3fe"/>
+			<Line Type="bytes" Address="0x01f8b5b0" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b5b5" Value="4d39eee913e1a3fe"/>
+			<Line Type="bytes" Address="0x01f8b5c0" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b5c5" Value="e9f9dfa3fe"/>
+			<Line Type="bytes" Address="0x01f8b5d0" Value="be01"/>
+			<Line Type="bytes" Address="0x01f8b5d5" Value="4c89f7e8d3289afee9bbf5c1fe"/>
+			<Line Type="bytes" Address="0x01f8b5f0" Value="4c89ff48c7c601"/>
+			<Line Type="bytes" Address="0x01f8b5fa" Value="e93af7c1fe"/>
+			<Line Type="bytes" Address="0x01f8b600" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b605" Value="4883c420e9aaeb20ff9090b801"/>
+			<Line Type="bytes" Address="0x01f8b615" Value="4883c428e9e25321ff"/>
+			<Line Type="bytes" Address="0x01f8b620" Value="48c7c001"/>
+			<Line Type="bytes" Address="0x01f8b627" Value="4883c428e9898621ffba01"/>
+			<Line Type="bytes" Address="0x01f8b635" Value="4585ffe9179621ff"/>
+			<Line Type="bytes" Address="0x01f8b640" Value="be01"/>
+			<Line Type="bytes" Address="0x01f8b645" Value="4585f6e9b99e21ff9090"/>
+			<Line Type="bytes" Address="0x01f8b650" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b655" Value="4883c428e93ab021ff90"/>
+			<Line Type="bytes" Address="0x01f8b660" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b665" Value="5b415ce991b121ff909090b801"/>
+			<Line Type="bytes" Address="0x01f8b675" Value="4883c4205be95d4624ff"/>
+			<Line Type="bytes" Address="0x01f8b680" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b685" Value="4883c4285be9bc4724ff90b801"/>
+			<Line Type="bytes" Address="0x01f8b695" Value="4883c4485be9370d26ff"/>
+			<Line Type="bytes" Address="0x01f8b6a0" Value="b801"/>
+			<Line Type="bytes" Address="0x01f8b6a5" Value="4883c428e997bf28ff"/>
+			<Line Type="bytes" Address="0x01f8b6b0" Value="bb01"/>
+			<Line Type="bytes" Address="0x01f8b6b5" Value="e98ca2c3ff9090"/>
+			<Line Type="bytes" Address="0x01f8b6c0" Value="83c603bb01"/>
+			<Line Type="bytes" Address="0x01f8b6c8" Value="e951a3c3ff9090"/>
+			<Line Type="bytes" Address="0x01f8b6d0" Value="41be01"/>
+			<Line Type="bytes" Address="0x01f8b6d6" Value="4129d6e802801cffe9bda4c3ff"/>			
+			<Line Type="bytes" Address="0x00a91c13" Value="e9789b4f01"/>
+			<Line Type="bytes" Address="0x01f8b790" Value="b90004000041b801000000e97b64b0fe"/>
+        </PatchList>
+    </Metadata>	
+</Patch>

--- a/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
+++ b/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
@@ -15,6 +15,8 @@
 			<Line Type="bytes" Address="0x012be8ae" Value="b901000000909048bfefbda9f950a65c9531f6909090"/>
 			<Line Type="bytes" Address="0x01311ba2" Value="9a94"/>
 			<Line Type="bytes" Address="0x0141de76" Value="b901000000909048bf88852e1f20bbad8b31f6909090"/>
+			<Line Type="bytes" Address="0x012be064" Value="eb19"/>
+			<Line Type="bytes" Address="0x0141de53" Value="b901000000909048bff9ad642611c886e431f6909090"/>			
         </PatchList>
     </Metadata>
 </Patch>

--- a/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
+++ b/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
@@ -2,11 +2,13 @@
 <Patch>
     <TitleID>
         <ID>CUSA23827</ID>
+	<ID>CUSA23029</ID>
+	<ID>CUSA34032</ID>
     </TitleID>
     <Metadata Title="Call of Duty Modern Warfare III (2023)"
               Name="Unlock All in Local Multiplayer"
               Author="zhm86 Credits: DeathRGH, DEv_ShOoTz, jydenx, YXBX, peekurchoo, Misaka_Mikoto_01, jocover and DuckBird"
-              Note="Unlock all 12 custom classes, attachments, blueprints, vests, gloves, boots, gears, operators, finishing moves, 5 hidden maps, 13 hidden game modes, and some dev options."
+              Note="Unlock all 12 custom classes, attachments, blueprints, vests, gloves, boots, gears, operators, finishing moves, 5 hidden maps, 13 hidden game modes, and some dev options. Remove the restriction of not being able to switch loadout during a match in split-screen mode."
               PatchVer="1.0"
               AppVer="01.33"
               AppElf="eboot.bin">

--- a/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
+++ b/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
@@ -5,7 +5,7 @@
     </TitleID>
     <Metadata Title="Call of Duty Modern Warfare III (2023)"
               Name="Unlock All in Local Multiplayer"
-              Author="zhm86 Credits: DeathRGH, DEv_ShOoTz, jydenx, YXBX, peekurchoo, jocover and DuckBird"
+              Author="zhm86 Credits: DeathRGH, DEv_ShOoTz, jydenx, YXBX, peekurchoo, Misaka_Mikoto_01, jocover and DuckBird"
               Note="Unlock all 12 custom classes, attachments, blueprints, vests, gloves, boots, gears, operators, finishing moves, 5 hidden maps, 13 hidden game modes, and some dev options."
               PatchVer="1.0"
               AppVer="01.33"

--- a/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
+++ b/patches/xml/CallOfDutyModernWarfareIII-Orbis.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+        <ID>CUSA23827</ID>
+    </TitleID>
+    <Metadata Title="Call of Duty Modern Warfare III (2023)"
+              Name="Unlock All in Local Multiplayer"
+              Author="zhm86 Credits: DeathRGH, DEv_ShOoTz, jydenx, YXBX, peekurchoo, jocover and DuckBird"
+              Note="Unlock all 12 custom classes, attachments, blueprints, vests, gloves, boots, gears, operators, finishing moves, 5 hidden maps, 13 hidden game modes, and some dev options."
+              PatchVer="1.0"
+              AppVer="01.33"
+              AppElf="eboot.bin">
+        <PatchList>
+			<Line Type="bytes" Address="0x012bdd25" Value="eb19"/>
+			<Line Type="bytes" Address="0x012be8ae" Value="b901000000909048bfefbda9f950a65c9531f6909090"/>
+			<Line Type="bytes" Address="0x01311ba2" Value="9a94"/>
+			<Line Type="bytes" Address="0x0141de76" Value="b901000000909048bf88852e1f20bbad8b31f6909090"/>
+        </PatchList>
+    </Metadata>
+</Patch>


### PR DESCRIPTION
Follow my twitter for latest COD series unlock all news: [https://x.com/zhm86x](https://x.com/zhm86x)

How to use: In the bottom of this post.
If any of my patches do not work, you can modify the CUSA number **both in patch file name and file content**, as long as the update **version number matches**.


Battlefield 2042 CUSA23249 Manual Map Mode Selection Patch by zhm86
Use this patch only with Battlefield 2042 CUSA23249 Offline AI Bot v1.75 released by Misaka_Mikoto_01 on June 30, 2026
[Battlefield 2042 Manual Map Mode Selection Patch by zhm86.zip](https://github.com/user-attachments/files/29669805/Battlefield.2042.Manual.Map.Mode.Selection.Patch.by.zhm86.zip)


COD MWII MWIII 1.36 PS4 CUSA34029 local multiplayer LAN unlock patch
[COD MWII MWIII 1.36 PS4 CUSA34029 local multiplayer LAN unlock patch-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14322849/COD.MWII.MWIII.1.36.PS4.CUSA34029.local.multiplayer.LAN.unlock.patch-zhm86.zip)


My unlock all patch has been integrated in Cyb1k's MWIII & MWII 1.36 release, and BO6 release, and I also fixed many other problems, check his release notes. No unlock all patch is needed for 1.36, everything is unlocked by my integrated patch. If you are using his 1.33 release, then you need the following patch.

For MWIII 1.33: 
Unlock all 12 custom classes, attachments, blueprints, vests, gloves, boots, gears, operators, finishing moves, 5 hidden maps, 13 hidden game modes, and some dev options. Credits: DeathRGH, DEv_ShOoTz, jydenx, YXBX, peekurchoo, jocover and DuckBird

Remove the restriction of not being able to switch loadout during a match for both players in split-screen mode.

Repeat following steps to add up 23 bots: 
Back to main menu, enter local multiplayer, create local game, choose a mode, check if you could add up to 15 bots at once. If you could only add up to 7 bots at once, go back to main menu and try again, this time you will success, if not, the third attempt will do.


MWIII 1.33 unlock all patch download
[CoD MWIII PS4 Unlock All in offline Local Multiplayer-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/13698567/CoD.MWIII.PS4.Unlock.All.in.offline.Local.Multiplayer-zhm86.zip)


Call of Duty Vanguard 1.26 PS4 unlock all & LAN & zombie split screen patch v1.3
(In v1.2 patch, if you don't connect your PS4 to WiFi or LAN, the unlock all does not work.
In v1.3 patch, unlock all will always work, no matter PS4 is connected to network or not. Thank @GamerHack for testing.)
In offline multiplayer and zombie, unlock all DLC weapons, blueprints, attachments, camouflages, reticles, charms, stickers, watches, operators, skins, finishing moves and highlights.
Unlock offline LAN play, enable 2 players zombie split screen.

[Call of Duty Vanguard 1.26 PS4 CUSA24041 unlock all and LAN and zombie split screen-v1.3-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/15137102/Call.of.Duty.Vanguard.1.26.PS4.CUSA24041.unlock.all.and.LAN.and.zombie.split.screen-v1.3-READ.INSTRUCTIONs.FIRST-zhm86.zip)


Call of Duty Vanguard 1.26 PS4 CUSA24041 unlock LAN and zombie split screen patch v1.1
Now you can play Vanguard zombie with SPLIT SCREEN offline!
I write instructions so you could split screen using 1 PS4 controller for Player 1, and regular PC mouse & keyboard for Player 2. Of course you could split screen using 2 PS4 controllers.

[Call of Duty Vanguard 1.26 PS4 CUSA24041 unlock LAN and zombie split screen-v1.1-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14897725/Call.of.Duty.Vanguard.1.26.PS4.CUSA24041.unlock.LAN.and.zombie.split.screen-v1.1-READ.INSTRUCTIONs.FIRST-zhm86.zip)

Black Ops Cold War PS4 v1.41 unlock all patch v1.7
Now zombie skills are truly Tier V.
Fix offline red rift easter egg in zombie outbreak round 3.
Apply final easter egg reward so your initial weapon will always be Epic rarity in zombie mode.

[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.7-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/29061070/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.7-READ.INSTRUCTIONs.FIRST-zhm86.zip)

<img width="1920" height="1080" alt="20260618_002249_00473900" src="https://github.com/user-attachments/assets/ef53ab28-61b4-47af-9e93-e9fd21bdaaad" />
<img width="1920" height="1080" alt="20260618_002314_00444670" src="https://github.com/user-attachments/assets/6c72bb4a-4c37-4898-86f7-15215e8e9142" />
<img width="1920" height="1080" alt="20260618_002321_00254865" src="https://github.com/user-attachments/assets/187897b7-7420-4b26-a7ce-1f9ab56d4b9d" />
<img width="1920" height="1080" alt="20260618_002545_00099719" src="https://github.com/user-attachments/assets/787bf477-dfc1-4866-a177-9a55437dcaca" />
<img width="1920" height="1080" alt="20260618_003034_00034209" src="https://github.com/user-attachments/assets/2d5bb07e-1ab0-4b51-8a00-59361ef18782" />


Black Ops Cold War PS4 v1.41 unlock all patch v1.6
All zombie skills upgraded to Tier V offline!
Offline zombie Easter Egg enabled defaultly.
Follow the instructions in cheat menu carefully.
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.6-English only-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/28520561/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.6-English.only-READ.INSTRUCTIONs.FIRST-zhm86.zip)
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.6-Spanish only-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/28531731/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.6-Spanish.only-READ.INSTRUCTIONs.FIRST-zhm86.zip)


<img width="1920" height="1080" alt="20260603_013621_00115458a" src="https://github.com/user-attachments/assets/ebef224f-c131-47a9-8207-9e037d86267d" />
<img width="1920" height="1080" alt="20260603_023936_00230927" src="https://github.com/user-attachments/assets/26941d1d-8be7-4566-bff0-e674a7f217f3" />
<img width="1920" height="1080" alt="20260603_024743_00995094" src="https://github.com/user-attachments/assets/0f004207-fde2-4033-83c6-e3130f4b98a4" />


Black Ops Cold War 1.41:
Cold War unlock all patch v1.5
Some online-only maps did not work, now they are fixed. You have to long press SHARE button to choose them.
They are: Amsterdam, Game Show, ICBM, KGB, Mansion, U-Bahn
They do not support bots, don't bother add bots on them.
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.5-English only-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/27403066/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.5-English.only-READ.INSTRUCTIONs.FIRST-zhm86.zip)
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.5-Spanish only-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/27403068/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.5-Spanish.only-READ.INSTRUCTIONs.FIRST-zhm86.zip)

Cold War unlock all patch v1.4
Add offline zombie easter egg enabler for ColdWar v1.41 English and Spanish only.
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.4-English only-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/27323351/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.4-English.only-READ.INSTRUCTIONs.FIRST-zhm86.zip)
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.4-Spanish only-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/27323352/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.4-Spanish.only-READ.INSTRUCTIONs.FIRST-zhm86.zip)


Cold War unlock all patch v1.3
Should work for all CUSA.
Offline Zombie Easter Egg enabler not working for 1.41 for now.
To unlock all the weapons and operators:
Long press SHARE button, tick the first option. DO NOT tick it until Main Menu(telephone) shows up.
Unlock online-only game mode and map.
Some online-only maps and game modes DO NOT have bot waypoints.
As always, accessories and something else could not be equipped.
[CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.3-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/21320967/CoD.BlackOpsColdWar.PS4.v1.41.Unlock.All.in.offline-v1.3-READ.INSTRUCTIONs.FIRST-zhm86.zip)

![20250719_021935_00184543](https://github.com/user-attachments/assets/126ea0be-00e5-4d2b-965e-7ec622673a17)
![20250719_022005_00726386](https://github.com/user-attachments/assets/c6626374-958a-4073-9388-48a6fe88281a)
![20250719_021152_00127578](https://github.com/user-attachments/assets/7b915f07-9dd0-4329-b9dd-f29e23e7c5d4)
![20250719_021546_00822316](https://github.com/user-attachments/assets/72f4ff34-a2d7-4f0b-83b2-23b99f0a8dad)
![20250719_021404_00694751](https://github.com/user-attachments/assets/7de0ac71-857a-434f-9a24-f78e7e0102c2)


Black Ops Cold War 1.27:
Cold War unlock all patch updated to v1.2 (Only update 1.27 CUSA24267 English is tested, other language/CUSA may not work.)
Add offline zombie easter egg enabler by ATE47. Unlock online-only maps in local multiplayer.
In local multiplayer, unlock all blueprints, accessories, stickers, finishing moves, gestures and bundle lockers.
Unlock Custom Classes to 12.

[CoD.BlackOpsColdWar.PS4.v1.27.CUSA24267.Unlock.All.in.offline-v1.2-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/15286993/CoD.BlackOpsColdWar.PS4.v1.27.CUSA24267.Unlock.All.in.offline-v1.2-READ.INSTRUCTIONs.FIRST-zhm86.zip)



Black Ops Cold War 1.27 unlock all patch download v1.1 (Modify CUSA number in file name and in file content yourself)
v1.1 update: DLC weapons and Operators are unlocked. Credit: Misaka_Mikoto_01
You could equip operators, but could not equip the skins of operators in operator menu. You could equip their skins in Bundle Locker.
[CoD.ColdWar.PS4.Unlock.All.in.offline.Local.Multiplayer.v1.1-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14127627/CoD.ColdWar.PS4.Unlock.All.in.offline.Local.Multiplayer.v1.1-zhm86.zip)


CoD MW2019 PS4 CUSA08829 Unlock All and COOP mode Split Screen unlock patch v1.1

Now you can play Survival and Classic Special Ops with SPLIT SCREEN offline!
Modern Warfare 2019 (MW19) unlock all patch v1.1 released.
I also write instructions so you could split screen using 1 PS4 controller for Player 1, and regular PC mouse & keyboard for Player 2.
[CoD MW2019 1.67 PS4 CUSA08829 Unlock All in offline Local Multiplayer-Unlock Split screen Coop-v1.1-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14864152/CoD.MW2019.1.67.PS4.CUSA08829.Unlock.All.in.offline.Local.Multiplayer-Unlock.Split.screen.Coop-v1.1-READ.INSTRUCTIONs.FIRST-zhm86.zip)
[CoD MW2019 1.22 PS4 CUSA15280 Unlock All in offline Local Multiplayer-Unlock Split screen Coop-v1.1-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14894258/CoD.MW2019.1.22.PS4.CUSA15280.Unlock.All.in.offline.Local.Multiplayer-Unlock.Split.screen.Coop-v1.1-READ.INSTRUCTIONs.FIRST-zhm86.zip)



[CoD MW2019 1.67 PS4 CUSA08829 Unlock All in offline Local Multiplayer-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14322855/CoD.MW2019.1.67.PS4.CUSA08829.Unlock.All.in.offline.Local.Multiplayer-zhm86.zip)
[CoD MW2019 1.63 PS4 CUSA08829 Unlock All in offline Local Multiplayer-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14322856/CoD.MW2019.1.63.PS4.CUSA08829.Unlock.All.in.offline.Local.Multiplayer-zhm86.zip)


Black Ops 4 1.26 unlock all patch v1.3 CUSA11100 English only
Fixed Perk: Blood Wolf Bite, Blaze Phase, Zombshell. Now you could use them all offline.
Thank @notryhardsnow-a11y for inspiration!
Reuploaded patch at UTC 2026-2-9 11:00, I overlooked some commas in json file.
[CoD.BlackOps4.PS4.v1.26.CUSA11100.Unlock.All.in.offline-v1.3-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/25181104/CoD.BlackOps4.PS4.v1.26.CUSA11100.Unlock.All.in.offline-v1.3-READ.INSTRUCTIONs.FIRST-zhm86.zip)
[CoD.BlackOps4.PS4.v1.26.CUSA12446.Spanish only.Unlock.All.in.offline-v1.3-READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/user-attachments/files/25181134/CoD.BlackOps4.PS4.v1.26.CUSA12446.Spanish.only.Unlock.All.in.offline-v1.3-READ.INSTRUCTIONs.FIRST-zhm86.zip)

![20260207_000153_00025719](https://github.com/user-attachments/assets/abcb7227-4a35-442c-af33-2cb8e7219a91)

Black Ops 4 1.26 unlock all patch download (Modify CUSA number in file name and in file content yourself)

BO4 UNLOCK ALL v1.2a patch:

v1.2a changelog: Update ReadMe
If you want to play Blackout after leaving Zombie lobby, make sure entering multiplayer lobby first, then quit multiplayer lobby and enter Blackout. If you enter Blackout right after leaving Zombie lobby, the game will freeze and crash. Thank @GamerHack for testing.

Offline zombie easter egg enabler by ATE47, ported and fixed HUD by me.
Blackout offline enabler by DeathRGH.
Unlock offline Elixirs, Talismans, and some black market stuff.
Reactive camos not work.
Make sure to read the instruction CAREFULLY.

Sorry everyone, the name string in my v1.1 patch is too long, makes the patch do not work.
If you have used my v1.1 patch, please follow these steps:
Delete old CUSA11100.xml in /user/data/GoldHEN/patches/xml/ , launch Cheat Manager, then quit.
Then copy the v1.2a cusa11100.xml to /user/data/GoldHEN/patches/xml/ , re-launch Cheat Manager and active the patch again to make it work.

[CoD.BlackOps4.PS4.v1.26.CUSA11100.Unlock.All.in.offline-v1.2a-ReadMe_Update READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14658973/CoD.BlackOps4.PS4.v1.26.CUSA11100.Unlock.All.in.offline-v1.2a-ReadMe_Update.READ.INSTRUCTIONs.FIRST-zhm86.zip)
[CoD.BlackOps4.PS4.v1.26.CUSA12446.Spanish only.Unlock.All.in.offline-v1.2a-ReadMe_Update READ INSTRUCTIONs FIRST-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14658974/CoD.BlackOps4.PS4.v1.26.CUSA12446.Spanish.only.Unlock.All.in.offline-v1.2a-ReadMe_Update.READ.INSTRUCTIONs.FIRST-zhm86.zip)


[CoD.BlackOps4.PS4.1.26.Unlock.All.in.offline.Local.Multiplayer.v1.0-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14127726/CoD.BlackOps4.PS4.1.26.Unlock.All.in.offline.Local.Multiplayer.v1.0-zhm86.zip)


CoD Infinite Warfare PS4 v1.25 unlock all patch v1.2 released
In the first 4 maps, you cannot pick up talismans after completing Easter Egg.
Don't worry, I have made modification, so you can fight the final boss Mephistopheles in the final map, even you don't have any talismans from other maps.
[CoD.InfiniteWarfare.PS4.v1.25.Unlock.All.in.offline-v1.2-DirectorsCut-fixFinalBossFight-zhm86.zip](https://github.com/user-attachments/files/28271931/CoD.InfiniteWarfare.PS4.v1.25.Unlock.All.in.offline-v1.2-DirectorsCut-fixFinalBossFight-zhm86.zip)


CoD Infinite Warfare PS4 v1.25 unlock all patch v1.1 released
You can play Director's Cut mode in offline and LAN now! All fortune cards are unlocked.
Will do research in enabling hidden characters for all maps.
[CoD.InfiniteWarfare.PS4.v1.25.Unlock.All.in.offline-v1.1-DirectorsCut-zhm86.zip](https://github.com/user-attachments/files/28196370/CoD.InfiniteWarfare.PS4.v1.25.Unlock.All.in.offline-v1.1-DirectorsCut-zhm86.zip)
<img width="1544" height="869" alt="19691231_211641_00233654" src="https://github.com/user-attachments/assets/c885d01c-9c5f-4e5f-bd5e-998efee5ad2c" />
<img width="1544" height="869" alt="19691231_221637_00384307" src="https://github.com/user-attachments/assets/e10720ca-1f04-4ee2-9957-d5ff00fc5018" />


Infinite Warfare PS4 v1.25 unlock all v1.0
Will do research of enable Director's Cut mode later.
[CoD.InfiniteWarfare.PS4.v1.25.Unlock.All.in.offline-v1.0-zhm86.zip](https://github.com/user-attachments/files/27481927/CoD.InfiniteWarfare.PS4.v1.25.Unlock.All.in.offline-v1.0-zhm86.zip)


Modern Warfare Remastered PS4 v1.15 Unlock all v1.0, including all DLC weapons, kits, camos, reticles, calling cards, emblems and character personalization in offline Local Multiplayer.
Only 5 custom classes for now, I can make it to 60, but have to use cheat table like my BO4 patch, may update in the future.
[CoD.ModernWarfareRemastered.PS4.v1.15.Unlock.All.in.offline-v1.0-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/14816549/CoD.ModernWarfareRemastered.PS4.v1.15.Unlock.All.in.offline-v1.0-zhm86.zip)


Black Ops 3 1.33 PS4 Unlock all v1.1 including DLC weapons, Mega Gobblegum, Black Market in offline Local Multiplayer.
However, Gun Smith, Emblems and Calling Cards are not working for now, may update in the future.
2024.5.20 fix name string too long causing patch not working
v1.1 changelog: Fix "Out of gobblegum" problem in Zombie mode.

[CoD BO3 1.33 PS4 Unlock DLC weapons, Mega Gobblegum, Black Market in offline Local Multiplayer v1.1-fix name string too long causing patch not working-zhm86.zip](https://github.com/illusion0001/PS4-PS5-Game-Patch/files/15379262/CoD.BO3.1.33.PS4.Unlock.DLC.weapons.Mega.Gobblegum.Black.Market.in.offline.Local.Multiplayer.v1.1-fix.name.string.too.long.causing.patch.not.working-zhm86.zip)


**How to use:**
1 Make sure using GoldHEN 2.3 or above. While jailbreaking, you could see GoldHEN version on upper left corner.
If not, update your GoldHEN payload in jailbreak process.

2 Download plugins. 
https://github.com/GoldHEN/GoldHEN_Plugins_Repository/releases/download/1.210-998fe03f/GoldPlugins-1.210-998fe03f.zip
Unpack all the files to PS4 /user/data/GoldHEN/
You can either use FTP to upload files from PC to PS4, or use USB portable disk with PS4-Xplorer 2.0 to copy over files.

3 Install GoldHEN Cheat Manager on PS4.
https://github.com/GoldHEN/GoldHEN_Cheat_Manager/releases/download/v1.1.4/IV0000-GOLD00777_00-GOLDCHEATS000PS4.pkg

4 Go to GoldHEN menu in the upper left corner in PS4 main screen.
Enable Cheat Menu in GoldHEN Cheat Settings.
Enable Plugins Loader AND Game Patch Plugin (If there is any) in GoldHEN Plugin Settings.

5 Download the unlock all patch you want.
Make new folders if there is not.
Unpack the unlock all patch, copy xml file to your PS4 /user/data/GoldHEN/patches/xml/
Copy json file (If there is any) to your PS4 /user/data/GoldHEN/cheats/json/ 

6 Launch GoldHEN Cheat Manager, click "Patch", choose your game, active the unlock all patch.
If there is not a STAR in front of the game name, that means the unlock all patch does not match the game.
Now check the following.
If your game version does not match the unlock all patch, you HAVE TO update the game.
If game update version matches, you can try modify the CUSA number **both in patch file name and file content**.
It may not work, especially if there is json file in patch.

7 Launch game. If you see prompt "XX lines patched!" on the upper left corner, you are all set.

Thank VicianaLab for making a detailed video of installing and activating the patch.
https://www.youtube.com/watch?v=5Rwf9qWJUq8

