### PR TITLE
Add no vsync for dying light 1.47

### DIFF
--- a/patches/xml/DyingLight.xml
+++ b/patches/xml/DyingLight.xml
@@ -13,7 +13,18 @@
   <Metadata Title="Dying Light"
               Name="No Vsync"
               Author="phrost1338"
-              Note="Let the intro movie play for a bit or the system will freeze up before the main menu."
+              Note="Let the intro movie play for a bit if the system freezes before the main menu."
+              PatchVer="1.0"
+              AppVer="01.47"
+              AppElf="eboot.bin">
+    <PatchList>
+        <Line Type="bytes" Address="0x47F196" Value="41b80200000090"/>
+    </PatchList>
+  </Metadata>
+  <Metadata Title="Dying Light"
+              Name="No Vsync"
+              Author="phrost1338"
+              Note="Let the intro movie play for a bit if the system freezes before the main menu."
               PatchVer="1.0"
               AppVer="01.48"
               AppElf="eboot.bin">


### PR DESCRIPTION
Same patch for 1.48 works on 1.47 without any changes.