### PR TITLE
Metal Gear Solid Snake Eater PPSA15304 v01.002.004 (Forces 30/60fps caps)

### DIFF
--- a/PPSA05754.xml
+++ b/PPSA05754.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+        <ID>PPSA05754</ID>
+    </TitleID>
+    <Metadata Title="The Matrix Awakens An Unreal Engine 5 Experience"
+              Name="60 fps"
+              Author="Joey85"
+              PatchVer="1.0"
+              AppVer="01.000.002"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x0691b7f8" Value="31F6"/>
+        </PatchList>
+    </Metadata>
+</Patch>

--- a/PPSA15304.xml
+++ b/PPSA15304.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <TitleID>
+        <ID>PPSA15304</ID>
+    </TitleID>
+    <Metadata Title="METAL GEAR SOLID SNAKE EATER Digital Deluxe Edition"
+              Name="Forces 60fps cap"
+              Author="Joey85"
+              PatchVer="1.0"
+              AppVer="01.002.004"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x04e2cb54" Value="c7c000007042"/>
+            <Line Type="bytes" Address="0x04e2cb5a" Value="660f6ec0"/>
+            <Line Type="bytes" Address="0x004e2cb5e" Value="90909090"/>
+            <Line Type="bytes" Address="0x04e2cb62" Value="eb09"/>				
+        </PatchList>
+    </Metadata>	
+    <Metadata Title="METAL GEAR SOLID SNAKE EATER Digital Deluxe Edition"
+              Name="Forces 30fps cap"
+              Author="Joey85"
+              PatchVer="1.0"
+              AppVer="01.002.004"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x04e2cb62" Value="9090"/>
+        </PatchList>
+    </Metadata>	
+</Patch>
+


### PR DESCRIPTION
Tested on the base PS5.
Forces 30 or 60fps caps allowing the user to select performance/quality modes without changing the framerate cap.