### PR TITLE
Update Alien Isolation 60/120fps patch

### DIFF
--- a/patches/xml/AlienIsolation-Orbis.xml
+++ b/patches/xml/AlienIsolation-Orbis.xml
@@ -3,7 +3,22 @@
     <TitleID>
         <ID>CUSA00362</ID>
         <ID>CUSA00363</ID>
-    </TitleID>
+    </TitleID>    
+    <Metadata Title="Alien: Isolation"
+              Name="60/120 FPS"
+			  Note="For 120fps also activate Patch VideoOut for 120Hz in the patch manager settings"
+              Author="Joey85"
+              PatchVer="1.0"
+              AppVer="01.04"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="bytes" Address="0x01199737" Value="be01"/>
+            <Line Type="bytes" Address="0x011995d0" Value="be01"/>
+            <Line Type="bytes" Address="0x01199530" Value="be01"/>
+            <Line Type="bytes" Address="0x0119944d" Value="be01"/>
+            <Line Type="bytes" Address="0x01022c6b" Value="be00"/>
+        </PatchList>
+    </Metadata>
     <Metadata Title="Alien: Isolation 1.04" Name="60 FPS" Note="Changes the engine target from 30 FPS to 60 FPS" Author="Jao" PatchVer="1.00" AppVer="01.00" AppElf="eboot.bin">
         <PatchList> 												   
            	<Line Type="bytes" Address="0x0101733c" Value="00"/>   


### PR DESCRIPTION
Tested on base PS5.
For 60fps use my patch OR "Patch VideoOut for 120Hz" in the patch manager "settings".
For 120fps use my patch AND "Patch VideoOut for 120Hz" in the patch manager "settings".